### PR TITLE
Fix documentation of make_slack_on_run_failure_sensor

### DIFF
--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -196,7 +196,7 @@ def make_slack_on_run_failure_sensor(
 
             @repository
             def my_repo():
-                return [my_job + slack_on_run_failure]
+                return [my_job, slack_on_run_failure]
 
         .. code-block:: python
 


### PR DESCRIPTION
### Summary & Motivation

This PR fixes the documentation of make_slack_on_run_failure_sensor.
The current example does not work as it fails with the error of `UserWarning: Error loading repository location slack_test.py:TypeError: unsupported operand type(s) for +: 'JobDefinition' and 'RunStatusSensorDefinition'`
https://dagster.slack.com/archives/C01U954MEER/p1647202482983529
